### PR TITLE
Add lint job in the github action workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,13 @@ jobs:
           override: true
           components: rustfmt, clippy
 
+      - name: Check source formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+
   build:
     runs-on: ubuntu-latest
     needs: lint

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,10 +3,22 @@ name: Rust
 on: [push]
 
 jobs:
+  lint:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Install stable rust release
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.39.0
+          override: true
+          components: rustfmt, clippy
+
   build:
-
     runs-on: ubuntu-latest
-
+    needs: lint
     steps:
     - uses: actions/checkout@v1
     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: Rust
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,10 @@ jobs:
           command: fmt
           args: --all -- --check
 
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
 
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # NazarustEngine
+
+![](https://github.com/NazaraEngine/NazaraEngine/workflows/Rust/badge.svg)
+
 An experiment to rewrite NazaraEngine using Rust

--- a/nazara_core/src/enums.rs
+++ b/nazara_core/src/enums.rs
@@ -129,7 +129,7 @@ pub enum PixelFormatType {
     /// 32 bits red/green unsigned integral pixel
     ///
     /// Stored in 2 uint32
-    RG32UI,   // 2*uint32
+    RG32UI,
     /// 16-bits RGBA pixel
     ///
     /// Stored in 3 uint5 and 1 alpha bit
@@ -145,7 +145,7 @@ pub enum PixelFormatType {
     /// 16 bits RGB signed integral pixel
     ///
     /// Stored in 4 int16
-    RGB16I,   // 4*int16
+    RGB16I,
     /// 16 bits RGB unsigned integral pixel
     ///
     /// Stored in 4 uint16

--- a/nazara_core/src/image.rs
+++ b/nazara_core/src/image.rs
@@ -6,6 +6,7 @@ use cgmath::Vector3;
 /// Mettre ici une description plus avancé, j'ai pas encore compris à quoi ça sert
 pub struct Image {
     dimensions: Vector3<usize>,
+    #[allow(dead_code)]
     content: Vec<Vec<u8>>,
     image_type: ImageType,
     pixel_format: PixelFormatType,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,15 @@
+#
+# Stable features only
+#
+
+edition = "2018"
 reorder_imports = true
+
+#
+# Current unstable features:
+#
+
+# Should be removed as soon as no other unstable feature is here
+unstable_features = true
+
 merge_imports = true


### PR DESCRIPTION
This MR enable formatting and clippy linting jobs for all merge request and adds the `Building success` badge from [1] Github.

It is worth noticing that it adds an `allow(dead_code)` to build correctly, which should be fixed in the future.

[1] https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#choosing-the-type-of-actions-for-your-workflow